### PR TITLE
Add comment about jest function 'it' being an alias for 'test' (#89)

### DIFF
--- a/manuscript/chapter4.md
+++ b/manuscript/chapter4.md
@@ -343,7 +343,7 @@ export {
 # leanpub-end-insert
 ~~~~~~~~
 
-In your *App.test.js* file, you will find a first test that came with *create-react-app*. It verifies that the App component would render without any errors.
+In your *App.test.js* file, you will find a first test that came with *create-react-app*. It verifies that the App component would render without any errors. Note that the `it` function in Jest is an alias for the `test` function.
 
 {title="src/App.test.js",lang=javascript}
 ~~~~~~~~


### PR DESCRIPTION
This reflects the underlying change in Jest 13.1 (https://github.com/facebook/jest/pull/1221) and the documentation of Jest (http://facebook.github.io/jest/docs/en/api.html#testname-fn) which mentions `it` now being an alias for `test` .